### PR TITLE
fix bootstrap error

### DIFF
--- a/scripts/bootstrap
+++ b/scripts/bootstrap
@@ -1,4 +1,5 @@
 #!/bin/bash
+
 set -e
 
 for dependency in git cue
@@ -6,8 +7,7 @@ do
     if ! which $dependency &> /dev/null; then
         echo "$dependency is missing from your \$PATH"
         exit 1
+    elif [ "$dependency" == "git" ]; then
+        git submodule update --init --recursive --remote
     fi
 done
-
-# Fetch our submodule from git
-./scripts/update


### PR DESCRIPTION
Fixes this error:

```
$ ./scripts/bootstrap    
fatal: Refusing to fetch into current branch refs/heads/main of non-bare repository
```