### PR TITLE
Remove examples namespace

### DIFF
--- a/k8s/grocerylist.yaml
+++ b/k8s/grocerylist.yaml
@@ -1,9 +1,4 @@
 apiVersion: v1
-kind: Namespace
-metadata:
-  name: examples
----
-apiVersion: v1
 data:
   index.html: An apple a day keeps the dentist away.
 kind: ConfigMap


### PR DESCRIPTION
Removing the examples namespace should fix the warning when applying the config