### PR TITLE
Add egress->redis to configure health checks correctly on all services

### DIFF
--- a/greymatter/grocerylist/apple.cue
+++ b/greymatter/grocerylist/apple.cue
@@ -2,6 +2,7 @@ package examples
 
 let Name = "apple"
 let AppleIngressName = "\(Name)-ingress-to-apple"
+let EgressToRedisName = "\(Name)-egress-to-redis"
 
 // Top level service objects enable programmatic access to service 
 // metadata when exported. Tagging can be used throughout the CUE
@@ -10,7 +11,7 @@ let AppleIngressName = "\(Name)-ingress-to-apple"
 // Each service object is REQUIRED to have a `config` array that contains
 // all associated mesh configurations as displayed below.
 Apple: {
-	name:   Name
+	name: Name
 	config: [
 		// Apple -> HTTP ingress
 		#domain & {domain_key: AppleIngressName},
@@ -25,11 +26,27 @@ Apple: {
 		#cluster & {cluster_key: AppleIngressName, _upstream_port: 8080},
 		#route & {route_key:     AppleIngressName},
 
+		// egress->redis
+		#domain & {domain_key: EgressToRedisName, port: defaults.ports.redis_ingress},
+		#cluster & {
+			cluster_key:  EgressToRedisName
+			name:         defaults.redis_cluster_name
+			_spire_self:  Name
+			_spire_other: defaults.redis_cluster_name
+		},
+		#route & {route_key: EgressToRedisName},
+		#listener & {
+			listener_key:  EgressToRedisName
+			ip:            "127.0.0.1" // egress listeners are local-only
+			port:          defaults.ports.redis_ingress
+			_tcp_upstream: defaults.redis_cluster_name // NB this points at a cluster name, not key
+		},
+
 		// Shared apple proxy object
 		#proxy & {
 			proxy_key: Name
-			domain_keys: [AppleIngressName]
-			listener_keys: [AppleIngressName]
+			domain_keys: [AppleIngressName, EgressToRedisName]
+			listener_keys: [AppleIngressName, EgressToRedisName]
 		},
 
 		// Edge config for the Apple service


### PR DESCRIPTION
Add egress to redis to each of the 4 grocerylist services.
Confirmed that after syncing, the changes were successfully applied to the services

Changes can be viewed here: http://13.86.96.68:10808/