### PR TITLE
update upstream greymatter-cue

### DIFF
--- a/EXPORT.cue
+++ b/EXPORT.cue
@@ -21,8 +21,8 @@ package grocerylist
 import (
 	// Point to the services folder in the mesh package since that's where we actually 
 	// define our mesh configs for individual applications.
-	core "examples.local/greymatter/core:examples"
-	grocerylist "examples.local/greymatter/grocerylist:examples"
+	core "greymatter.io.examples/greymatter/core:greymatter"
+	grocerylist "greymatter.io.examples/greymatter/grocerylist:greymatter"
 )
 
 grocerylist_config:

--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@ and the [CUE playground](https://cuelang.org/play/#cue@export@cue).
   CUE schemas.
 * `greymatter`: A directory of example CUE configs. These configs are all known
   to work with greymatter.io `v1.7.0+`.
-* `./greymatter/inputs.cue`: A CUE file in `package examples` that contains
+* `./greymatter/inputs.cue`: A CUE file in `package greymatter` that contains
   defaults, overrides, and user generated values.
-* `./greymatter/intermediates.cue`: A CUE file in `package examples` containing
+* `./greymatter/intermediates.cue`: A CUE file in `package greymatter` containing
   default greymatter.io configurations. Many default HTTP filter configs can be
   found in this file.
 * `EXPORT.cue`: A file storing the final CUE keys to export. The fields must be

--- a/cue.mod/module.cue
+++ b/cue.mod/module.cue
@@ -1,1 +1,1 @@
-module: "examples.local"
+module: "greymatter.io.examples"

--- a/greymatter/core/edge.cue
+++ b/greymatter/core/edge.cue
@@ -4,7 +4,7 @@
 // greymatter.io edge that is deployed via enterprise-level configuration in
 // the gitops-core git repository.
 
-package examples
+package greymatter
 
 let EgressToRedisName = "\(defaults.edge.key)_egress_to_redis"
 
@@ -41,7 +41,7 @@ edge_config: [
 	// so that Catalog will be able to look-up edge instances
 	#cluster & {cluster_key: defaults.edge.key},
 
-	// egress->redis
+	// egress -> redis
 	#domain & {domain_key: EgressToRedisName, port: defaults.ports.redis_ingress},
 	#cluster & {
 		cluster_key:  EgressToRedisName
@@ -52,7 +52,7 @@ edge_config: [
 	#route & {route_key: EgressToRedisName},
 	#listener & {
 		listener_key:  EgressToRedisName
-		ip:            "127.0.0.1" // egress listeners are local-only
+		ip:            "127.0.0.1"
 		port:          defaults.ports.redis_ingress
 		_tcp_upstream: defaults.redis_cluster_name
 	},
@@ -63,7 +63,7 @@ edge_config: [
 		listener_keys: [defaults.edge.key, EgressToRedisName]
 	}
 
-	// egress->Keycloak for OIDC/JWT Authentication (only necessary with remote JWKS provider)
+	// egress -> Keycloak for OIDC/JWT Authentication (only necessary with remote JWKS provider)
 	// NB: You need to add the EdgeToKeycloakName key to the domain_keys and listener_keys 
 	// in the #proxy above for the cluster to be discoverable by the sidecar
 	// #cluster & {
@@ -71,7 +71,7 @@ edge_config: [
 	//  _upstream_host: defaults.edge.oidc.endpoint_host
 	//  _upstream_port: defaults.edge.oidc.endpoint_port
 	//  ssl_config: {
-	//   protocols: ["TLSv1_2"]
+	//   protocols: ["TLS_AUTO"]
 	//   sni: defaults.edge.oidc.endpoint_host
 	//  }
 	//  require_tls: true
@@ -81,5 +81,5 @@ edge_config: [
 	// #listener & {
 	//  listener_key: EdgeToKeycloakName
 	//  port:         defaults.edge.oidc.endpoint_port
-	// },
+	// },,
 ]

--- a/greymatter/grocerylist/apple.cue
+++ b/greymatter/grocerylist/apple.cue
@@ -1,4 +1,4 @@
-package examples
+package greymatter
 
 let Name = "apple"
 let AppleIngressName = "\(Name)-ingress-to-apple"
@@ -26,7 +26,7 @@ Apple: {
 		#cluster & {cluster_key: AppleIngressName, _upstream_port: 8080},
 		#route & {route_key:     AppleIngressName},
 
-		// egress->redis
+		// egress -> redis
 		#domain & {domain_key: EgressToRedisName, port: defaults.ports.redis_ingress},
 		#cluster & {
 			cluster_key:  EgressToRedisName
@@ -36,13 +36,15 @@ Apple: {
 		},
 		#route & {route_key: EgressToRedisName},
 		#listener & {
-			listener_key:  EgressToRedisName
-			ip:            "127.0.0.1" // egress listeners are local-only
-			port:          defaults.ports.redis_ingress
-			_tcp_upstream: defaults.redis_cluster_name // NB this points at a cluster name, not key
+			listener_key: EgressToRedisName
+			// egress listeners are local-only
+			ip:   "127.0.0.1"
+			port: defaults.ports.redis_ingress
+			// NB this points at a cluster name, not key
+			_tcp_upstream: defaults.redis_cluster_name
 		},
 
-		// Shared apple proxy object
+		// Shared Apple proxy object
 		#proxy & {
 			proxy_key: Name
 			domain_keys: [AppleIngressName, EgressToRedisName]
@@ -70,12 +72,12 @@ Apple: {
 			prefix_rewrite: "/"
 		},
 
-		#catalogentry & {
+		#catalog_entry & {
 			name:                      Name
 			mesh_id:                   mesh.metadata.name
 			service_id:                Name
 			version:                   "v1.0.0"
-			description:               "Apple service that serves up apples!"
+			description:               "Apple service that serves up apples"
 			api_endpoint:              "/services/\(Name)/"
 			api_spec_endpoint:         "/services/\(Name)/"
 			business_impact:           "low"

--- a/greymatter/grocerylist/banana.cue
+++ b/greymatter/grocerylist/banana.cue
@@ -1,4 +1,4 @@
-package examples
+package greymatter
 
 let Name = "banana"
 let BananaIngressName = "\(Name)-ingress-to-banana"
@@ -24,7 +24,7 @@ Banana: {
 		#cluster & {cluster_key: BananaIngressName, _upstream_port: 8080},
 		#route & {route_key:     BananaIngressName},
 
-		// egress->redis
+		// egress -> redis
 		#domain & {domain_key: EgressToRedisName, port: defaults.ports.redis_ingress},
 		#cluster & {
 			cluster_key:  EgressToRedisName
@@ -34,10 +34,12 @@ Banana: {
 		},
 		#route & {route_key: EgressToRedisName},
 		#listener & {
-			listener_key:  EgressToRedisName
-			ip:            "127.0.0.1" // egress listeners are local-only
-			port:          defaults.ports.redis_ingress
-			_tcp_upstream: defaults.redis_cluster_name // NB this points at a cluster name, not key
+			listener_key: EgressToRedisName
+			// egress listeners are local-only
+			ip:   "127.0.0.1"
+			port: defaults.ports.redis_ingress
+			// NB this points at a cluster name, not key
+			_tcp_upstream: defaults.redis_cluster_name
 		},
 
 		// Shared Banana proxy object
@@ -68,13 +70,12 @@ Banana: {
 			prefix_rewrite: "/"
 		},
 
-		// Grey Matter catalog service entry
-		#catalogentry & {
+		#catalog_entry & {
 			name:                      Name
 			mesh_id:                   mesh.metadata.name
 			service_id:                Name
 			version:                   "v0.0.1"
-			description:               "Banana service that serves up bananas!"
+			description:               "Banana service that serves up bananas"
 			api_endpoint:              "/services/\(Name)/"
 			api_spec_endpoint:         "/services/\(Name)/"
 			business_impact:           "low"

--- a/greymatter/grocerylist/lettuce.cue
+++ b/greymatter/grocerylist/lettuce.cue
@@ -1,4 +1,4 @@
-package examples
+package greymatter
 
 let Name = "lettuce"
 let LettuceIngressName = "\(Name)-ingress-to-lettuce"
@@ -25,7 +25,7 @@ Lettuce: {
 		#cluster & {cluster_key: LettuceIngressName, _upstream_port: 8080},
 		#route & {route_key:     LettuceIngressName},
 
-		// egress->redis
+		// egress -> redis
 		#domain & {domain_key: EgressToRedisName, port: defaults.ports.redis_ingress},
 		#cluster & {
 			cluster_key:  EgressToRedisName
@@ -35,20 +35,22 @@ Lettuce: {
 		},
 		#route & {route_key: EgressToRedisName},
 		#listener & {
-			listener_key:  EgressToRedisName
-			ip:            "127.0.0.1" // egress listeners are local-only
-			port:          defaults.ports.redis_ingress
-			_tcp_upstream: defaults.redis_cluster_name // NB this points at a cluster name, not key
+			listener_key: EgressToRedisName
+			// egress listeners are local-only
+			ip:   "127.0.0.1"
+			port: defaults.ports.redis_ingress
+			// NB this points at a cluster name, not key
+			_tcp_upstream: defaults.redis_cluster_name
 		},
 
-		// Shared lettuce proxy object
+		// Shared Lettuce proxy object
 		#proxy & {
 			proxy_key: Name
 			domain_keys: [LettuceIngressName, EgressToRedisName]
 			listener_keys: [LettuceIngressName, EgressToRedisName]
 		},
 
-		// Edge config for the lettuce service
+		// Edge config for the Lettuce service
 		#cluster & {
 			cluster_key:  Name
 			_spire_other: Name
@@ -69,12 +71,12 @@ Lettuce: {
 			prefix_rewrite: "/"
 		},
 
-		#catalogentry & {
+		#catalog_entry & {
 			name:                      Name
 			mesh_id:                   mesh.metadata.name
 			service_id:                Name
 			version:                   "v1.0.0"
-			description:               "Lettuce service that serves up lettuce!"
+			description:               "Lettuce service that serves up lettuce"
 			api_endpoint:              "/services/\(Name)/"
 			api_spec_endpoint:         "/services/\(Name)/"
 			business_impact:           "low"

--- a/greymatter/grocerylist/tomato.cue
+++ b/greymatter/grocerylist/tomato.cue
@@ -1,4 +1,4 @@
-package examples
+package greymatter
 
 let Name = "tomato"
 let TomatoIngressName = "\(Name)-ingress-to-tomato"
@@ -13,7 +13,7 @@ let EgressToRedisName = "\(Name)-egress-to-redis"
 Tomato: {
 	name: Name
 	config: [
-		// tomato -> HTTP ingress
+		// Tomato -> HTTP ingress
 		#domain & {domain_key: TomatoIngressName},
 		#listener & {
 			listener_key:          TomatoIngressName
@@ -25,7 +25,7 @@ Tomato: {
 		#cluster & {cluster_key: TomatoIngressName, _upstream_port: 8080},
 		#route & {route_key:     TomatoIngressName},
 
-		// egress->redis
+		// egress -> redis
 		#domain & {domain_key: EgressToRedisName, port: defaults.ports.redis_ingress},
 		#cluster & {
 			cluster_key:  EgressToRedisName
@@ -35,20 +35,22 @@ Tomato: {
 		},
 		#route & {route_key: EgressToRedisName},
 		#listener & {
-			listener_key:  EgressToRedisName
-			ip:            "127.0.0.1" // egress listeners are local-only
-			port:          defaults.ports.redis_ingress
-			_tcp_upstream: defaults.redis_cluster_name // NB this points at a cluster name, not key
+			listener_key: EgressToRedisName
+			// egress listeners are local-only
+			ip:   "127.0.0.1"
+			port: defaults.ports.redis_ingress
+			// NB this points at a cluster name, not key
+			_tcp_upstream: defaults.redis_cluster_name
 		},
 
-		// Shared tomato proxy object
+		// Shared Tomato proxy object
 		#proxy & {
 			proxy_key: Name
 			domain_keys: [TomatoIngressName, EgressToRedisName]
 			listener_keys: [TomatoIngressName, EgressToRedisName]
 		},
 
-		// Edge config for the tomato service
+		// Edge config for the Tomato service
 		#cluster & {
 			cluster_key:  Name
 			_spire_other: Name
@@ -69,12 +71,12 @@ Tomato: {
 			prefix_rewrite: "/"
 		},
 
-		#catalogentry & {
+		#catalog_entry & {
 			name:                      Name
 			mesh_id:                   mesh.metadata.name
 			service_id:                Name
 			version:                   "v1.0.0"
-			description:               "Tomato service that serves up tomato!"
+			description:               "Tomato service that serves up tomato"
 			api_endpoint:              "/services/\(Name)/"
 			api_spec_endpoint:         "/services/\(Name)/"
 			business_impact:           "low"

--- a/greymatter/inputs.cue
+++ b/greymatter/inputs.cue
@@ -1,7 +1,8 @@
-package examples
+package greymatter
 
 config: {
-	spire: bool | *false @tag(spire,type=bool) // enable Spire-based mTLS
+	// enable Spire-based mTLS
+	spire: bool | *false @tag(spire,type=bool)
 }
 
 mesh: {

--- a/greymatter/intermediates.cue
+++ b/greymatter/intermediates.cue
@@ -1,4 +1,4 @@
-package examples
+package greymatter
 
 import (
 	greymatter "greymatter.io/api"
@@ -8,23 +8,43 @@ import (
 	fault "envoyproxy.io/extensions/filters/http/fault/v3"
 	ext_authz "envoyproxy.io/extensions/filters/http/ext_authz/v3"
 	ext_authz_tcp "envoyproxy.io/extensions/filters/network/ext_authz/v3"
+	lua "envoyproxy.io/extensions/filters/http/lua/v3"
 )
 
 /////////////////////////////////////////////////////////////
-// "Functions" for Grey Matter config objects with defaults
-// representing an ingress to a local service. Override-able.
+// "Functions" for greymatter.io config objects with defaults
+// reflecting common local service configuration. All of which
+// can be overriden.
 /////////////////////////////////////////////////////////////
 
+// #domain represents a greymatter domain object, which deals with incoming 
+// requests to the service.
+// See https://docs.greymatter.io/service-mesh/domain for more details.
 #domain: greymatter.#Domain & {
+	// Set _force_https to true to turn on secure traffic to the service.
+	// For edge services that want TLS, this should be enabled
 	_force_https: bool | *false
-	domain_key:   string
-	name:         string | *"*"
-	port:         int | *defaults.ports.default_ingress
-	zone_key:     mesh.spec.zone
-	force_https:  _force_https
+	// Identifers for the domain object within the mesh
+	domain_key: string
+	name:       string | *"*"
+	// Port to access the service on
+	port: int | *defaults.ports.default_ingress
+	// Designates which zone the object belongs to
+	zone_key: mesh.spec.zone
+	// Configures TLS settings for incoming requests, utilizing 
+	// mounted certificates to allow for HTTPS traffic
+	force_https: _force_https
 	if _force_https == true {
 		ssl_config: greymatter.#SSLConfig & {
-			protocols: [ "TLSv1_2"]
+			// Specify a TLS Protocol to use when communicating
+			// Supported options are:
+			// TLS_AUTO TLSv1_0 TLSv1_1 TLSv1_2 TLSv1_3
+			protocols: [ "TLS_AUTO"]
+			// TLS certificate defaults, if enabled.
+			// These paths are created via volume mounts to the container
+			// That we specify in the k8s manifests for the service.
+			// If these files are mounted in a different location, change
+			// these paths.
 			trust_file: "/etc/proxy/tls/sidecar/ca.crt"
 			cert_key_pairs: [
 				greymatter.#CertKeyPathPair & {
@@ -36,34 +56,75 @@ import (
 	}
 }
 
+// #listener represents a greymatter listener object, which provide avenues to 
+// receive traffic for the proxy. They have filters which can act based on
+// incoming requests. 
+// See https://docs.greymatter.io/service-mesh/listener for more details.
 #listener: greymatter.#Listener & {
-	_tcp_upstream?:              string        // for TCP listeners, you can just specify the upstream cluster
-	_is_ingress:                 bool | *false // specifiy if this listener is for ingress which will active default HTTP filters
-	_gm_observables_topic:       string        // unique topic name for observable audit collection
-	_spire_self:                 string        // can specify current identity - defaults to "edge"
-	_spire_other:                string        // can specify an allowable downstream identity - defaults to "edge"
+	// For TCP listeners, you can just specify the upstream cluster
+	_tcp_upstream?: string
+	// Specifiy if this listener is for ingress, which will activate default HTTP filters
+	_is_ingress: bool | *false
+	// Unique topic name for observable audit collection
+	// See https://docs.greymatter.io/filters/observables for more details.
+	_gm_observables_topic: string
+
+	// These options are for configuring traffic that utilizes
+	// SPIFFE/SPIRE for automatic mTLS protection.
+	// Can specify current identity
+	// Set by default to the name of the service.    
+	_spire_self: string
+	// Can specify an allowable downstream identity
+	// Set by default to the name of the service.      
+	_spire_other: string
+
+	// These toggles enable filters for use with a service.
+	// Each toggle provides a default config that can be overridden
+	// in the CUE file for a service. Note that some toggles may 
+	// activate more than one filter, such as OIDC.
+	// More information about each filter can be found with their
+	// configuration within the network_filters or http_filters section.
 	_enable_rbac:                bool | *false
 	_enable_fault_injection:     bool | *false
 	_enable_oidc_authentication: bool | *false
-	_enable_inheaders:           bool | *false
-	_enable_impersonation:       bool | *false
-	_oidc_endpoint:              string
-	_oidc_service_url:           string
-	_oidc_provider:              string
-	_oidc_client_id:             string
-	_oidc_client_secret:         string
-	_oidc_cookie_domain:         string
-	_oidc_realm:                 string
-	_enable_tcp_rate_limit:      bool | *false // You must include a service->rate limiter service cluster. HTTP/2
-	_enable_ext_authz:           bool | *false // you must create a service->ext authz service cluster. HTTP/2 only if auth server is grpc
+	// Inheaders and impersonation require mTLS at the edge and inside the mesh.
+	_enable_inheaders:     bool | *false
+	_enable_impersonation: bool | *false
+	// For TCP rate limiting, you must include a service->rate limiter service cluster using HTTP/2
+	_enable_tcp_rate_limit: bool | *false
+	// For external authorization you must create a service->ext authz service cluster. 
+	// If auth server is grpc, HTTP/2 only
+	_enable_ext_authz: bool | *false
 
+	// Set of configurable values for use in OIDC configurations
+	// and populated by inputs.cue if applicable.
+	// Do not change theses values in the service, rather make 
+	// the change within inputs.cue
+	_oidc_endpoint:      string
+	_oidc_service_url:   string
+	_oidc_provider:      string
+	_oidc_client_id:     string
+	_oidc_client_secret: string
+	_oidc_cookie_domain: string
+	_oidc_realm:         string
+
+	// Identifiers for the object within the mesh
 	listener_key: string
 	name:         listener_key
-	ip:           string | *"0.0.0.0"
-	port:         int | *defaults.ports.default_ingress
-	domain_keys:  [...string] | *[listener_key]
+	// IP and port that the listener should process requests for
+	ip:   string | *"0.0.0.0"
+	port: int | *defaults.ports.default_ingress
+	// List of domains for this listener to be attached to.
+	// Change this in your service if you have more than one
+	// domain, or if you use a different string for your domain
+	// and listener keys.
+	domain_keys: [...string] | *[listener_key]
 
+	// For TCP listeners.
 	if _tcp_upstream != _|_ {
+		// This active_network_filters list contains the filters which will be active on the listener.
+		// NB: Even if configuration exists in network_filters for a filter,
+		// only filters which are listed as active will be applied and used.
 		active_network_filters: [
 			if _enable_ext_authz {
 				"envoy.ext_authz"
@@ -71,37 +132,58 @@ import (
 			if _enable_tcp_rate_limit {
 				"envoy.rate_limit"
 			},
+			// Needs to be last in filter chain
 			"envoy.tcp_proxy",
+			...string,
 		]
 		network_filters: {
+			// Configures rate limiting for TCP listeners.
+			// See #envoy_tcp_rate_limit below for the default 
+			// configuration and more detail on using this filter.
+			// Also see the envoy docs for more information:
+			// https://www.envoyproxy.io/docs/envoy/v1.16.5/configuration/listeners/network_filters/rate_limit_filter
 			if _enable_tcp_rate_limit {
 				envoy_rate_limit: #envoy_tcp_rate_limit
 			}
 
+			// Allows for external authorization of requests.
+			// See the envoy docs for more information:
+			// https://www.envoyproxy.io/docs/envoy/v1.16.5/configuration/listeners/network_filters/ext_authz_filter
 			if _enable_ext_authz {
-				envoy_ext_authz: #envoy_tcp_ext_authz
+				envoy_ext_authz: #envoy_tcp_ext_authz // See XXX for default values
 			}
-
-			// Needs to be last in filter chain
 			envoy_tcp_proxy: {
-				cluster:     _tcp_upstream // NB: contrary to the docs, this points at a cluster *name*, not a cluster_key
+				// NB: contrary to the docs, this points at a cluster *name*, not a cluster_key
+				cluster:     _tcp_upstream
 				stat_prefix: _tcp_upstream
 			}
 		}
 	}
 
-	// if there isn't a tcp cluster, then assume http filters, and provide the usual defaults
+	// Non-TCP listeners that are ingress can have HTTP filters applied to them
 	if _tcp_upstream == _|_ && _is_ingress == true {
+
+		// The active_http_filters list contains the filters which will be active on the listener.
+		// NB: Even if configuration exists in http_filters for a filter,
+		// only filters which are listed as active will be applied and used.
+		// To add custom filters, introduce a new toggle above and match the
+		// pattern below to place it correctly in the chain. 
 		active_http_filters: [
 			if _enable_fault_injection {
 				"envoy.fault"
 			},
+			// Note: Inheaders and impersonation only function when mTLS is active
+			// throughout the mesh, via Spire or another means. Also, gm.inheaders
+			// and gm.impersonation generally aren't set on the same proxy.
 			if _enable_inheaders {
 				"gm.inheaders"
 			},
 			if _enable_impersonation {
 				"gm.impersonation"
 			},
+			// Note that only one filter can be added per conditional expression.
+			// These four filters allow the OIDC authentication flow to facilitate
+			// additional policies like RBAC.
 			if _enable_oidc_authentication {
 				"gm.oidc-authentication"
 			},
@@ -111,6 +193,11 @@ import (
 			if _enable_oidc_authentication {
 				"gm.oidc-validation"
 			},
+			if _enable_oidc_authentication {
+				"envoy.lua"
+			},
+			// This filter is essential to the operation of the mesh and should
+			// not be disabled.
 			"gm.observables",
 			if _enable_oidc_authentication {
 				"envoy.jwt_authn"
@@ -121,10 +208,19 @@ import (
 			if _enable_rbac {
 				"envoy.rbac"
 			},
+			// This filter is essential to the operation of the mesh and should
+			// not be disabled.
 			"gm.metrics",
 			...string,
 		]
+
+		// http_filters contains the configuration for HTTP filters (not TCP)
+		// potentially applied to the listener. Note again that the active_http_filters
+		// list controls which filters are actually used with incoming requests.
 		http_filters: {
+			// gm_metrics collects real-time statistics for the running service
+			// and serves them to a metrics scraper like Prometheus. These defaults should
+			// work for most use cases. 
 			gm_metrics: {
 				metrics_host:                               "0.0.0.0"
 				metrics_port:                               defaults.ports.metrics
@@ -139,11 +235,14 @@ import (
 					push_interval_seconds:   10
 				}
 			}
+			// gm_observables configures the proxy to emit information about each request made to 
+			// the service for audits.
 			gm_observables: {
 				topic: _gm_observables_topic
 			}
 			if _enable_oidc_authentication {
 				"gm_oidc-authentication": #oidc_authentication & {
+					// These values are populated from inputs.cue
 					serviceUrl:   _oidc_service_url
 					provider:     _oidc_provider
 					clientId:     _oidc_client_id
@@ -180,7 +279,7 @@ import (
 					userInfo: {
 						location: *"header" | _
 						// USER_DN header is currently required for observables
-						// application to show user audit data
+						// application to show user audit data.
 						key: "USER_DN"
 						claims: ["name"]
 					}
@@ -191,6 +290,17 @@ import (
 						caPath:             string | *""
 						insecureSkipVerify: bool | *false
 					}
+				}
+				// Use Lua pattern matching to get the user's name from encoded JSON object.
+				"envoy_lua": lua.#Lua & {
+					inline_code: """
+							function envoy_on_request(handle)
+								local user_dn = handle:headers():get('USER_DN')
+								parsed_user_dn = string.match(user_dn, '%%7B%%22name%%22:%%22(.*)%%22%%7D')
+								parsed_user_dn = string.gsub(parsed_user_dn, '%%20', ' ')
+								handle:headers():replace('USER_DN', parsed_user_dn)
+							end
+						"""
 				}
 				"envoy_jwt_authn": #envoy_jwt_authn & {
 					providers: defaults.edge.oidc.jwt_authn_provider
@@ -224,16 +334,18 @@ import (
 			// _spire_other: "edge"  // but this defaults to "edge" and may be omitted
 			_name:    _spire_self
 			_subject: _spire_other
-			// TODO I just copied the following two from the previous operator without knowing why -DC
-			set_current_client_cert_details: uri: true
+			set_current_client_cert_details: URI: true
 			forward_client_cert_details: "APPEND_FORWARD"
 		}
 	}
 
 	zone_key: mesh.spec.zone
-	protocol: "http_auto" // vestigial
+	protocol: "http_auto"
 }
 
+// #cluster represents "upstream" or outgoing traffic from the proxy. Generally, this is
+// the service fronted by the proxy but could be any network address. #cluster can support
+// TLS configuration to the upstream service.
 #cluster: greymatter.#Cluster & {
 	// You can either specify the upstream with these, or leave it to service discovery
 	_upstream_host:           string | *"127.0.0.1"
@@ -264,19 +376,25 @@ import (
 	zone_key: mesh.spec.zone
 
 	if _enable_circuit_breakers {
-		circuit_breakers: #circuit_breaker // can specify circuit breaker levels for normal
-		// and high priority traffic with configured defaults
+		// circuit_breakers can specify circuit breaker levels for normal and high
+		// priority traffic with configured defaults
+		circuit_breakers: greymatter.#CircuitBreakersThresholds & {
+			#circuit_breakers_default
+			high?: #circuit_breakers_default
+		}
 	}
+
+	// Allows for configuration of a load balancer, designated by the policy type.
 	if _load_balancer != _|_ {
 		lb_policy: _load_balancer
 		if lb_policy == "least_request" {
-			least_request_lb_conf: {
+			least_request_lb_config: {
 				choice_count: uint32 | *2
 			}
 		}
 
 		if lb_policy == "ring_hash" || lb_policy == "maglev" {
-			ring_hash_lb_conf: {
+			ring_hash_lb_config: {
 				minimum_ring_size?: uint64 & <8388608 | *1024
 				hash_func?:         uint32 | *0                  //corresponds to the xxHash; 1 for MURMUR_HASH_2 
 				maximum_ring_size?: uint64 & <8388608 | *4194304 // 4M
@@ -285,12 +403,10 @@ import (
 	}
 }
 
-#circuit_breaker: {
-	#circuit_breaker_default
-	high?: #circuit_breaker_default
-}
-
-#circuit_breaker_default: {
+// #circuit_breakers_default provides default circuit breaker values.
+// Setting _enable_circuit_breakers: true on the #cluster will use these values
+// unless overriden.
+#circuit_breakers_default: {
 	max_connections:      int64 | *512
 	max_pending_requests: int64 | *512
 	max_requests:         int64 | *512
@@ -299,6 +415,7 @@ import (
 	track_remaining:      bool | *false
 }
 
+// #route represents the URL path to a service in the mesh.
 #route: greymatter.#Route & {
 	route_key:               string
 	domain_key:              string | *route_key
@@ -323,18 +440,20 @@ import (
 	}
 }
 
+// #proxy represents the sum total of all configurations sent to data plane proxy. This includes listeners,
+// domains, routes, and clusters.
 #proxy: greymatter.#Proxy & {
 	proxy_key:     string
 	name:          proxy_key
-	domain_keys:   [...string] | *[proxy_key] // TODO how to get more in here for, e.g., the extra egresses?
+	domain_keys:   [...string] | *[proxy_key]
 	listener_keys: [...string] | *[proxy_key]
 	zone_key:      mesh.spec.zone
 }
 
 #spire_secret: {
-	_name:    string | *defaults.edge.key // at least one of these will be overridden
+	_name:    string | *defaults.edge.key
 	_subject: string | *defaults.edge.key
-	_subjects?: [...string] // If provided, this list of strings will be used instead of _subject
+	_subjects?: [...string]
 
 	set_current_client_cert_details?: {...}
 	forward_client_cert_details?: string
@@ -350,8 +469,10 @@ import (
 	ecdh_curves: ["X25519:P-256:P-521:P-384"]
 }
 
-// Allows for RBAC permissions to be applied to a service and its configuration
+// #envoy_rbac_filter allows for RBAC permissions to be applied to a service and its configuration.
 #envoy_rbac_filter: rbac.#RBAC | *#default_rbac
+
+// #default_rbac allows all traffic to flow with no restriction.
 #default_rbac: {
 	rules: {
 		action: "ALLOW"
@@ -372,9 +493,9 @@ import (
 	}
 }
 
-// This filter is used by OIDC/JWT authentication and ensures that the access_token JWT
-// that is present as a cookie is copied into the header of the request
-// so that it can be accessed by the envoy_jwt_authn filter.
+// #ensure_variables_filter is used by OIDC/JWT authentication and ensures that
+// the access_token JWT that is present as a cookie is copied into the header
+// of the request so that it can be accessed by the envoy_jwt_authn filter.
 #ensure_variables_filter: {
 	rules: [...#ensure_variables_rules] | *[
 		{
@@ -390,8 +511,8 @@ import (
 	]
 }
 
-// If other variables need to be copied/used in other filters, this filter provides
-// a template for those rules.
+// #ensure_variables_rule provides a template for copying data from one filter to another,
+// such as cookies and headers.
 #ensure_variables_rules: {
 	key:      string
 	location: string
@@ -401,10 +522,12 @@ import (
 	}]
 }
 
-// This filter allows for the JWT supplied by an OIDC provider to be validated and 
+// #envoy_jwt_authn allows for the JWT supplied by an OIDC provider to be validated and 
 // used in other contexts, such as RBAC configurations.
 #envoy_jwt_authn: jwt_authn.#JwtAuthentication & {
 	providers: {
+		// keycloak configuration is specific to Keycloak. If using another provider, you will need to
+		// create separate set of configurations and change the provider_name in the rules below.
 		keycloak?: {
 			issuer:    string | *""
 			audiences: [...string] | *[""]
@@ -427,12 +550,12 @@ import (
 	rules: [...] | *[
 		{
 			match: {prefix: "/"}
-			requires: {provider_name: "keycloak"}
+			requires: {provider_name: "keycloak"} //This name is configurable 
 		},
 	]
 }
 
-// Allows for authentication via an OIDC provider such as Keycloak.
+// #oidc_authentication allows for authentication via an OIDC provider such as Keycloak.
 #oidc_authentication: {
 	provider:     string | *""
 	serviceUrl:   string | *""
@@ -487,15 +610,15 @@ import (
 	}
 
 	// Optional requested permissions
-	additionalScopes: [...string] | *["openid"]
+	additionalScopes: [...string] | *["openid"] //This scope is required for OIDC
 }
 
 #envoy_tcp_rate_limit: ratelimit.#RateLimit | *#default_rate_limit
 
-// Assumes the http/2 cluster between proxy and the rate limit service is called ratelimit.
-// see https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/other_features/global_rate_limiting#arch-overview-global-rate-limit for a discussion of ratelimiting and 
-// special descriptors to use
-#default_rate_limit: {
+// #default_rate_limit assumes the http/2 cluster between proxy and the rate limit service is called ratelimit.
+// See https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/other_features/global_rate_limiting#arch-overview-global-rate-limit
+// for a discussion of ratelimiting and special descriptors to use.
+#default_rate_limit: ratelimit.#RateLimit & {
 	stat_prefix:       defaults.edge.key
 	domain:            defaults.edge.key
 	failure_mode_deny: true
@@ -512,16 +635,15 @@ import (
 	rate_limit_service: {
 		grpc_service: {
 			envoy_grpc: {
-				timeout:      "0.25s"
 				cluster_name: "ratelimit"
 			}
 		}
 	}
 }
 
-// Allows for the configuration of fault injection into a proxy
-// See https://www.envoyproxy.io/docs/envoy/v1.16.5/configuration/http/http_filters/fault_filter.html for header/runtime configuration
-// specifics, along with further configuration for specific upstream clusters
+// #envoy_fault_injection allows for the configuration of fault injection into a proxy
+// See https://www.envoyproxy.io/docs/envoy/v1.16.5/configuration/http/http_filters/fault_filter.html
+// for header/runtime configuration specifics, along with further configuration for specific upstream clusters.
 #envoy_fault_injection: fault.#HTTPFault | *{
 	delay: {
 		fixed_delay: "5s"
@@ -531,7 +653,7 @@ import (
 		}
 	}
 	abort: {
-		// Allows request to specify the status code with which to fail using the x-envoy-fault-abort-request header
+		// header_abort allows request to specify the status code with which to fail using the x-envoy-fault-abort-request header
 		header_abort: {} // Headers can also specify the percentage of requests to fail, capped by the below value with the x-envoy-fault-abort-request-percentage header
 		percentage: {
 			numerator:   50
@@ -545,7 +667,7 @@ import (
 #envoy_ext_authz: ext_authz.#ExtAuthz | *{
 	grpc_service: {
 		envoy_grpc: {
-			cluster_name: "ext_authz" // Needs to match the name of your cluster. Since its a grpc connection, you must create an http/2 cluster
+			cluster_name: "opa" // Needs to match the name of your cluster. Since its a grpc connection, you must create an http/2 cluster
 		}
 	}
 	failure_mode_allow: false // set to true to allow requests to pass in the case of a authz network failure
@@ -565,7 +687,8 @@ import (
 	failure_mode_allow: false // set to true to allow requests to pass in the case of a authz network failure
 }
 
-#OPAEgress: {
+// #opa_egress configures egress to an OPA service for external authorization.
+#opa_egress: {
 	input: {
 		name:       string
 		domain_key: string
@@ -587,4 +710,4 @@ import (
 	}
 }
 
-#catalogentry: greymatter.#CatalogService
+#catalog_entry: greymatter.#CatalogService


### PR DESCRIPTION
Changes:

- update upstream greymatter-cue
- copy gm/intermediates.cue from gitops-core
- cleaned up comments in service CUE files

Make sure everything evals - `cue eval -c EXPORT.cue --out yaml -e configs`.