### PR TITLE
Replace + with list.Concat

### DIFF
--- a/EXPORT.cue
+++ b/EXPORT.cue
@@ -21,17 +21,23 @@ package grocerylist
 import (
 	// Point to the services folder in the mesh package since that's where we actually 
 	// define our mesh configs for individual applications.
+	"list"
 	core "greymatter.io.examples/greymatter/core:greymatter"
 	grocerylist "greymatter.io.examples/greymatter/grocerylist:greymatter"
 )
 
 grocerylist_config:
-	grocerylist.Banana.config +
-	grocerylist.Apple.config +
-	grocerylist.Lettuce.config +
-	grocerylist.Tomato.config
+	list.Concat([
+		grocerylist.Banana.config,
+		grocerylist.Apple.config,
+		grocerylist.Lettuce.config,
+		grocerylist.Tomato.config,
+	])
 
 configs:
 	// The edge config must come first because services create routes
 	// that reference the edge domain.
-	core.Edge.config + grocerylist_config
+	list.Concat([
+		core.Edge.config,
+		grocerylist_config
+	])


### PR DESCRIPTION
[sc-28198]

With list concatenations this small, it doesn't directly matter whether you use `+` or `list.Concat`, but because this is an example repository, it's important to change it to the performant option (`list.Concat`) anyway. This is largely so that we don't encourage users to do the wrong thing for when it _does_ matter. 